### PR TITLE
Add caveat for sed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ the above migration steps.
      's/0x2E645469f354BB4F5c8a05B3b30A929361cf77eC/<GANACHE_CONTRACT_ADDRESS>/g' \
      subgraph.yaml
    ```
+    Check out the [docs](https://www.gnu.org/software/sed/manual/sed.html) if you don't know what sed does. Basically, it replaces the hardcoded contract address `0x2E645469f354BB4F5c8a05B3b30A929361cf77eC` with the address of your locally-deployed `GravityRegistry` contract.
+
 5. Deploy the subgraph to your local Graph Node:
    ```sh
    graph create --node http://localhost:8020/ <GITHUB_USERNAME>/example-subgraph


### PR DESCRIPTION
I didn't know what `sed` was doing prior to following The Graph's docs and I got into a nasty situation where the following step was just not working for me:

```bash
$ sed -i -e \
    's/0x2E645469f354BB4F5c8a05B3b30A929361cf77eC/<CONTRACT_ADDRESS>/g' \
    subgraph.yaml
```

And it turns out that it worked the **first** time, but then on subsequent executions (I compiled and migrated the contracts more than once), `sed` was trying to replace a value that didn't exist anymore.

Therefore, I thought to add a little caveat in the README for noobs like me :)