### PR TITLE
Missing --from-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ the above migration steps.
 
 1. Ceate a new example subgraph with:
    ```sh
-   graph init <GITHUB_USERNAME>/example-subgraph
+   graph init --from-example <GITHUB_USERNAME>/example-subgraph
    ```
 2. Follow the instructions for installing dependencies and running
    the code generation (typically: `yarn && yarn codegen`).


### PR DESCRIPTION
The command `graph init` will expect a live deployed contract on mainnet or testnet, but will not allow for using a local testnet. The `--from-example` command will allow a user to follow the tutorial past this point.